### PR TITLE
Fixed a link, &ndash; in inline code and missing characters in pakage option

### DIFF
--- a/FAQ-backref.md
+++ b/FAQ-backref.md
@@ -22,7 +22,7 @@ antiquity (it's derived from a LaTeX 2.09 package).
 
 Neither collapses
 lists of pages (`5, 6, 7` comes out as such, rather than as
-`5&ndash;7`), but neither package repeats the reference to a page that
+`5-7`), but neither package repeats the reference to a page that
 holds multiple citations.  (The failure to collapse lists is of course
 forgiveable in the case of the [`hyperref`](https://ctan.org/pkg/hyperref)-related
 [`backref`](https://ctan.org/pkg/backref), since the concept of multiple hyperlinks from the

--- a/FAQ-citesort.md
+++ b/FAQ-citesort.md
@@ -15,7 +15,7 @@ that sort of thing for no more improvement than ''[2,3,4,6]''?
 
 The [`cite`](https://ctan.org/pkg/cite) package sorts the numbers and detects consecutive
 sequences, so creating ''[2&ndash;4,6]''.  The [`natbib`](https://ctan.org/pkg/natbib) package,
-with the `numbers` and `sor & ompress` options, will
+with the `numbers` and `sort&compress` options, will
 do the same when working with its own numeric bibliography styles
 (`plainnat.bst` and `unsrtnat.bst`).
 

--- a/FAQ-htmlbib.md
+++ b/FAQ-htmlbib.md
@@ -21,5 +21,5 @@ styles, and post-process the output so produced using a
 A more conventional translator is the `awk` script
 `bbl2html`, which translates the `bbl` file you've generated:
 a sample of the script's output may be viewed on the web, at
-[http://rikblok.cjb.net/lib/refs.html]
+<http://rikblok.cjb.net/lib/refs.html>
 


### PR DESCRIPTION
concerning the https://github.com/texfaq/texfaq.github.io/commits?author=samcarter8: Is there a better way to write an en-dash in inline code?