### PR TITLE
Add texfaq.org permalink to footer

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,7 +7,8 @@ layout: default
 {{content}}
 
 {% if page.path contains "FAQ-" %}
-  <p><small>FAQ ID: <a href="index#{{ page.path  | remove_first: ".md" }}">{{ page.path | remove_first: "FA" | remove_first: ".md" }}</a>
+  <p><small>FAQ ID: <a href="index#{{ page.path  | remove_first: ".md" }}">{{ page.path | remove_first: "FA" | remove_first: ".md" }}</a><br/>
+  <small>Permalink: <a href="http://texfaq.org/{{ page.path  | remove_first: ".md" }}">http://texfaq.org/{{ page.path  | remove_first: ".md" }}</a>
   {% if page.tags %}
     <br />Tags:&nbsp;
       {%- for tag in page.tags -%}


### PR DESCRIPTION
In the light of https://github.com/texfaq/texfaq.github.io/commit/f1cb286d12c67c10ac611ffcb33f1e5cb6fa7f6c it might be a nice touch to have the permalink to the canonical URL shown in the footer of the page.

This pull requests puts the line
> Permalink: http://texfaq.org/FAQ-<title>

in the footer directly below the FAQ ID.