### PR TITLE
Recommend `footnotehyper` for footnotes in tables

### DIFF
--- a/FAQ-footintab.md
+++ b/FAQ-footintab.md
@@ -47,7 +47,7 @@ advice, you can:
     footnotes.
 -  Use [`tablefootnote`](https://ctan.org/pkg/tablefootnote); it provides a command `\tablefootnote`,
     which does the job without fuss.
--  Use [`footnote`](https://ctan.org/pkg/footnote), which provides an
+-  Use [`footnotehyper`](https://ctan.org/pkg/footnotehyper), which provides an
     `savenotes` which collects all footnotes and emits them
     at the end of the environment; thus if you put your
     `tabular` environment inside a `savenotes`


### PR DESCRIPTION
The `footnotehyper` package is a rewrite of `footnote` (last updated in 1996), providing the same functionality but avoiding the incompatibilities with `hyperref`, `xcolor`, and other packages.