### PR TITLE
FAQ-repeat-set: Correction in the example of code for package `dowith`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ file. Changes prior to the switch to Markdown format are available from
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2021-12-27
+
+### Changed
+
+- Q-repeat-set: Correction in the example of code for `dowith`.
+
 ## 2021-11-28
 
 ### Changed
@@ -91,7 +97,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Q-eqnarray and other pages, update "AMSLaTeX" references to amsmath
+- Q-eqnarray and other pages: update "AMSLaTeX" references to amsmath
   package or amsmath bundle.
 
 ## 2018-06-27
@@ -128,7 +134,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Q-MP: Mention LuaTeX integration of MetaPost.
-- Q-archives Germany is now the only CTAN hub.
+- Q-archives: Germany is now the only CTAN hub.
 
 ## 2018-05-27
 
@@ -162,7 +168,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Q-xetex-luatex: New combination question based on Q-xetex and Q-luatex
 - Q-t1enc drop this (redirect to Q-why-inp-font)
-- Q-why-inp-font Update this (after 2018 release changes)
+- Q-why-inp-font: Update this (after 2018 release changes)
 
 ### Changed
 - Q-LaTeX2HTML: Update with more recent converters such as LaTeXML and lwarp.

--- a/FAQ-getnff.md
+++ b/FAQ-getnff.md
@@ -7,7 +7,7 @@ permalink: /FAQ-getnff
 Some fonts are free to use, but may not be sold.  This creates a
 dilemma for distributions: users may want the fonts, but since the
 distribution is also available on a DVD for sale, the fonts may
-not be in the distribtution.
+not be in the distribution.
 
 The CTAN archives hold such fonts, together with all the
 necessary support files, but even with the support files ready-made,

--- a/FAQ-inst-wlcf.md
+++ b/FAQ-inst-wlcf.md
@@ -42,7 +42,7 @@ The
 [MiKTeX documentation](https://docs.miktex.org/manual/initexmf.html)
 gives further details about `initexmf`.
 
-On a TeX&nbsp;Live-based system (or its predecessor teTeX, use the command
+On a TeX&nbsp;Live-based system (or its predecessor teTeX), use the command
 `texhash` (or if that's not available, `mktexlsr`&nbsp;&mdash;
 they ought to be different names for the same program).
 

--- a/FAQ-repeat-set.md
+++ b/FAQ-repeat-set.md
@@ -12,38 +12,38 @@ seemingly simple task of repeating an operation.  This answer deals
 with repeating an operation for each of a given set of objects.
 
 The [`etoolbox`](https://ctan.org/pkg/etoolbox) package provides iteration over a
-comma-separated list of items, in its `\docsvlist` and
-`\forcsvlist` commands; they are well-described in the package
-documentation.  The [`datatool`](https://ctan.org/pkg/datatool) package manages "databases"
-(of its own definition) and you may iterate over entries in such a
-database using the command `\DTLforeach`.
+comma-separated list of items, in its `\docsvlist` and `\forcsvlist` commands;
+they are well-described in the package documentation.
+The [`datatool`](https://ctan.org/pkg/datatool) package manages "databases"
+(of its own definition) and you may iterate over entries in such a database
+using the command `\DTLforeach`.
 
 The [`forarray`](https://ctan.org/pkg/forarray) package defines its own "list" and "array"
 structures, together with commands `\ForEach` and `\ForArray`
-which enable a command to be executed for each element in a list or
-array, respectively.
+which enable a command to be executed for each element in a list or array, respectively.
 
-The [`dowith`](https://ctan.org/pkg/dowith) defines a pair of macros `\DoWith` and
-`\StopDoing` that process each "thing" between them; a trivial
-example of use is:
+The [`dowith`](https://ctan.org/pkg/dowith) defines a pair of macros `\DoWith`
+and `\StopDoing` that process each "thing" between them;
+a trivial example of use is:
 ```latex
 \usepackage{dowith}
 ...
 \begin{document}
-\newcommand{\foo}[1]{\message{#1+}
+
+\newcommand{\foo}[1]{\message{#1+}}
+
 \DoWith\foo a{BBB}c\StopDoing
 ```
 which produces terminal output:
-```latex
+```
 a+ BBB+ c+
 ```
-so, the macros have found 3 "things", including one with braces
-around it.  (The interpolated spaces come from the primitive
-`\message` command.)
+so, the macros have found 3 "things", including one with braces around it.
+(The interpolated spaces come from the primitive `\message` command.)
 
 The only constraint is that all commands in the enclosed stuff are
-"expandable" (which means, for example, that you may not use
-commands with optional arguments).
+"expandable" (which means, for example, that you may not use commands
+with optional arguments).
 
 From the same stable (as [`dowith`](https://ctan.org/pkg/dowith)) comes the package
 [`commado`](https://ctan.org/pkg/commado), that provides commands `\DoWithCSL` (apply a


### PR DESCRIPTION
 Hello,

A closing curly bracket was missing in the example of code for package `dowith`, in page [`FAQ-repeat-set`](https://github.com/texfaq/texfaq.github.io/blob/main/FAQ-repeat-set.md).
(also, the output of this example is in the terminal, so it doesn't need to be formatted as LaTeX code).

Season's greetings!
Jérémy.