### PR TITLE
Updated Vim and Kile links

### DIFF
--- a/FAQ-editors.md
+++ b/FAQ-editors.md
@@ -22,7 +22,7 @@ personal selection:
   within the editor, and everything else like this that you can think
   of.  Complex, but very powerful.
 
-  [`Vim`](https://vim.sourceforge.net) is also highly
+  [`Vim`](https://www.vim.org/) is also highly
   configurable (also available for Windows and Macintosh systems).
   Many plugins are available to support the needs of the (La)TeX user,
   including syntax highlighting, calling TeX programs,
@@ -47,7 +47,7 @@ personal selection:
   window manager provides GUI "shell-like" facilities, in a
   similar way to the widely-praised `Winedt` (see below);
   details (and downloads) are available from the project's
-  [home on SourceForge](https://kile.sourceforge.net/).
+  [home on SourceForge](https://kile.sourceforge.io).
 
   TUG is sponsoring the development of a cross-platform editor
   and shell, modelled on the excellent TeXshop for the Macintosh.


### PR DESCRIPTION
Amended link from vim.sourceforge.net to vim.org
Amended link from kile.sourceforge.net to kile.sourceforge.io