### PR TITLE
Q-alternatives: add Typst

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -104,4 +104,4 @@ The following people are _known_ to have contributed to the FAQ:
 - Rick Zaccone
 - Gregor Zattler
 - Reinhard Zierke
-
+- Martin Haug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ file. Changes prior to the switch to Markdown format are available from
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2023-04-29
+
+### Changed
+
+- Q-alternatives: Add Typst.
+
 ## 2022-02-06
 
 ### Changed

--- a/FAQ-alternatives.md
+++ b/FAQ-alternatives.md
@@ -2,7 +2,7 @@
 title: Alternatives to TeX
 category: misc
 permalink: /FAQ-alternatives
-date: 2018-05-24
+date: 2023-04-29
 redirect_from: /FAQ-ant
 ---
 
@@ -15,6 +15,12 @@ The projects listed here are entirely distinct from TeX or its derivatives
 (they are not "TeX-like" programs).
 
 ## Active projects
+
+### Typst
+[Typst](https://typst.app/) is a typesetting system written in Rust. It uses a
+markdown-like input syntax and includes an interpreted scripting language. Typst
+focuses on being easy to learn and create templates for and features fast
+compile times.
 
 ### Patoline
 


### PR DESCRIPTION
This PR adds [Typst](https://github.com/typst/typst), a scientific typesetting system developed by @laurmaedje and me to the list of LaTeX alternatives.

We believe that Typst is, despite being quite new, relevant for this question, since it has achieved 16,000 GitHub stars already and is used by people in the wild, see our Discord.

I added the subsection at the top of the list, please get back to me if I should move it to the bottom or sort the entries alphabetically!