### PR TITLE
Fix typos in FAQs

### DIFF
--- a/FAQ-2colfltorder.md
+++ b/FAQ-2colfltorder.md
@@ -9,7 +9,7 @@ several "defer" lists.  If another float of the same type comes
 along, and the "defer" list for that type still has something in it,
 the later float has to wait for everything earlier in the list.
 
-Prior to teh 2015 release LaTeX had different lists for single-column floats,
+Prior to the 2015 release LaTeX had different lists for single-column floats,
 and double-column floats; this meant that single-column figures could
 overtake double-column figures (or vice-versa), and you observed later
 figures appear in the document before early ones.  The same was true,

--- a/FAQ-LaTeX2HTML.md
+++ b/FAQ-LaTeX2HTML.md
@@ -32,7 +32,7 @@ Today, with native MathML rendering in some browsers
 and high quality math rendering available via JavaScript and CSS
 in all modern graphical browsers there are several possibilities.
 
-The LaTeX to HTML convertors listed below  all handle mathematics
+The LaTeX to HTML converters listed below  all handle mathematics
 to some extent, and further math-specific details are discussed
 in [Math on the Web](FAQ-mathml).
 
@@ -49,7 +49,7 @@ For today, possible packages are:
 
   Configuring and calling `TeX4ht` can be quite complicated,
   Michal Hoftich's `make4ht` system provides an alternative
-  easier calling convention, using the `tex4ht` convertor internally.
+  easier calling convention, using the `tex4ht` converter internally.
 
 - `LaTeXML` From [NIST](https://www.nist.gov/) is a perl program
   that can parse most TeX code, including complicated macro definitions.
@@ -57,7 +57,7 @@ For today, possible packages are:
   from LaTeX sources. Currently it is distributed from the NIST site, and is not
   in standard TeX distributions.
 
-- `lwarp` by Brian Dunn is a recent TeX to HTML convertor that uses
+- `lwarp` by Brian Dunn is a recent TeX to HTML converter that uses
    TeX to parse the input document. Documents may be produced by LaTeX, LuaLaTeX, or XeLaTeX.
    A texlua script removes the need for system utilities such as make and gawk,
    and also supports xindy and latexmk. [CTAN](https://ctan.org/pkg/lwarp).
@@ -91,7 +91,7 @@ For today, possible packages are:
 
 - `plasTeX` a Python-based LaTeX document processing
     framework.  It gives DOM-like access to a LaTeX document, as
-    well as the ability to generate mulitple output formats
+    well as the ability to generate multiple output formats
     (e.g. HTML, DocBook, tBook, etc.).
 
 - `TeXpider` a commercial program from

--- a/FAQ-PSpreview.md
+++ b/FAQ-PSpreview.md
@@ -30,7 +30,7 @@ have a couple options:
     [`ghostscript`](https://www.ghostscript.com/) fonts) to
     make PK bitmap fonts which
     your previewer will understand (a process similar to the way some
-    browsers fo the job "automatically") This can produce adequate results,
+    browsers for the job "automatically") This can produce adequate results,
     also suitable for printing with non-PostScript devices.  (Note: if you
     purchased the fonts, it is advisable to check that their licence
     permits you to convert them, for private use, in this way.)

--- a/FAQ-addtoreset.md
+++ b/FAQ-addtoreset.md
@@ -37,12 +37,12 @@ can also use it:
 The [`chngcntr`](https://ctan.org/pkg/chngcntr) package encapsulates the `\@addtoreset`
 command into a command `\counterwithin`.  So:
 ```latex
-\counterwithin*{corrollary}{theorem}
+\counterwithin*{corollary}{theorem}
 ```
 will make the corollary counter slave to theorem counters.  The
 command without its asterisk:
 ```latex
-\counterwithin{corrollary}{theorem}
+\counterwithin{corollary}{theorem}
 ```
 will do the same, and also redefine `\thecorollary` as 
 &lsaquo;_theorem number_&rsaquo;.&lsaquo;_corollary number_&rsaquo;, which is a good scheme

--- a/FAQ-arraytab.md
+++ b/FAQ-arraytab.md
@@ -24,6 +24,6 @@ some specific parameters. As an example, the space between two columns is set
 separately, using `\arraycolsep` for `array` and `\tabcolsep` for `tabular`.
 
 A very useful LaTeX package is named [`array`](https://ctan.org/pkg/array).
-Despite its name, it provides advanced functionnalities for both `array` and
+Despite its name, it provides advanced functionalities for both `array` and
 `tabular` environments (and their relatives).
 

--- a/FAQ-biblatex.md
+++ b/FAQ-biblatex.md
@@ -35,7 +35,7 @@ BibTeX&ndash;LaTeX, two stand out for their availability and usage:
 The [`biblatex`](https://ctan.org/pkg/Biblatex) package provides a programmable
 approach to creating bibliographies in which control takes place in the (La)TeX
 code, rather than a BibTeX style file. This means that output can be modified
-on a per-document basis. Moreover, with full availablity of the data in the
+on a per-document basis. Moreover, with full availability of the data in the
 LaTeX run, a much wider range of bibliographic outcomes are possible. This is
 particularly important in supporting citation styles in the humanities. The
 `biblatex` package also integrates many ideas from existing BibTeX-focussed

--- a/FAQ-cmdstar.md
+++ b/FAQ-cmdstar.md
@@ -67,7 +67,7 @@ definition like:
 For those of an adventurous disposition, a further option is to use
 the [`xparse`](https://ctan.org/pkg/xparse) package from the [`l3packages`](https://ctan.org/pkg/l3packages)
 distribution.  The package defines a bunch of commands (such as
-`\NewDocumentCommand`) which are somewhat analagous to
+`\NewDocumentCommand`) which are somewhat analogous to
 `\newcommand` and the like, in LaTeX2e.  The big difference is
 the specification of command arguments; for each argument, you have a
 set of choices in the command specification.  So, to create a

--- a/FAQ-conditional.md
+++ b/FAQ-conditional.md
@@ -56,7 +56,7 @@ file.  The package requires a current pdfTeX, and will also run on
 LuaTeX if the [`pdftexcmds`](https://ctan.org/pkg/pdftexcmds) package is available
 ([`pdftexcmds`](https://ctan.org/pkg/pdftexcmds) emulates the requisite pdfTeX commands using
 `lua`.  Apart from this requirement, [`stampinclude`](https://ctan.org/pkg/stampinclude) is
-a low-maintenace object; include it in your document and it silently
+a low-maintenance object; include it in your document and it silently
 does its job.  When you want a final version of your document, delete
 all the `aux` files, and and [`stampinclude`](https://ctan.org/pkg/stampinclude) won't
 interfere.)
@@ -164,7 +164,7 @@ There are then commands
 \tagged{<tag list>}{<text>}
 ```
 which reproduces the text only if the &lsaquo;_tag list_&rsaquo; contains at
-least one tag listed in the `\usetag` comand, and
+least one tag listed in the `\usetag` command, and
 ```latex
 \untagged{<tag list>}{<text>}
 ```

--- a/FAQ-fixwidtab.md
+++ b/FAQ-fixwidtab.md
@@ -33,7 +33,7 @@ between them.
 The [`tabulary`](https://ctan.org/pkg/tabulary) package (by the same author) provides a way of
 "balancing" the space taken by the columns of a table.  The package
 defines column specifications `C`, `L`, `R` and
-`J`, giving, respectively, centerd, left, right and
+`J`, giving, respectively, centered, left, right and
 fully-justified versions of space-sharing columns.  The package
 examines how long each column would be "naturally" (i.e., on a piece of paper of unlimited width), and
 allocates space to each column accordingly.  There are

--- a/FAQ-fontsize.md
+++ b/FAQ-fontsize.md
@@ -18,7 +18,7 @@ significantly applies to the default (Computer Modern) and the
 Cork-encoded (T1) EC fonts, but it is widely considered to be
 anomalous, nowadays.  In recognition of this problem, there is a
 package [`fix-cm`](https://ctan.org/pkg/fix-cm) which will allow you to use the fonts, within
-LaTeX, at any size you choose.  If you're not using scaleable
+LaTeX, at any size you choose.  If you're not using scalable
 versions of the fonts, most modern distributions will just generate an
 appropriate bitmap for you.
 
@@ -54,5 +54,5 @@ packages, or the [`anyfontsize`](https://ctan.org/pkg/anyfontsize) package.
 A further alternative might be to switch to the
 [_Latin Modern_ fonts](FAQ-uselmfonts) (which
 provide a close simulacrum of the _Computer Modern_ set);
-these fonts were scaleable from their first
+these fonts were scalable from their first
 distribution, and don't therefore need any such trick as the above.

--- a/FAQ-fontunavail.md
+++ b/FAQ-fontunavail.md
@@ -31,10 +31,10 @@ LaTeX's list of "allowed" sizes for this font; LaTeX has
 chosen the nearest font size it knows is allowed.  In fact, you can
 tell LaTeX to allow _any_ size: the restrictions come from the
 days when only bitmap fonts were available, and they have never
-applied to fonts that come in scaleable form in the first place.
+applied to fonts that come in scalable form in the first place.
 Nowadays, most of the fonts that were once bitmap-only are also
-available in scaleable (Adobe Type&nbsp;1) form.  If your installation uses
-scaleable versions of the Computer Modern or European Computer Modern
+available in scalable (Adobe Type&nbsp;1) form.  If your installation uses
+scalable versions of the Computer Modern or European Computer Modern
 (EC) fonts, you can tell LaTeX to remove the restrictions;
 use the [`type1cm`](https://ctan.org/pkg/type1cm) or [`type1ec`](https://ctan.org/pkg/type1ec) package as appropriate.
 

--- a/FAQ-graph-pspdf.md
+++ b/FAQ-graph-pspdf.md
@@ -1,6 +1,6 @@
 ---
 title: Portable imported graphics
-cateogry: graphics
+category: graphics
 permalink: /FAQ-graph-pspdf
 ---
 

--- a/FAQ-install-unpack.md
+++ b/FAQ-install-unpack.md
@@ -1,6 +1,6 @@
 ---
 title: Unpacking LaTeX packages
-cateogry: installing
+category: installing
 permalink: /FAQ-install-unpack
 ---
 

--- a/FAQ-keyval.md
+++ b/FAQ-keyval.md
@@ -92,7 +92,7 @@ systems; some notable differences are:
 -  [`pgfkeys`](https://ctan.org/pkg/pgfkeys) can support call-backs when an unknown key
     appears (these things are called _handlers_.
 
-Keys are organized in a tree that is reminiscent of the Unix fille
+Keys are organized in a tree that is reminiscent of the Unix file
 tree.  A typical key might be, `/tikz/coordinate system/x` or
 just `/x`.  When you specify keys you can provide the complete
 path of the key, but you usually just provide the name of the key

--- a/FAQ-linmacnames.md
+++ b/FAQ-linmacnames.md
@@ -5,7 +5,7 @@ tags: macros
 permalink: /FAQ-linmacnames
 ---
 
-New LaTeX users are often suprised that macro definitions
+New LaTeX users are often surprised that macro definitions
 containing non-letters, such as
 ```latex
 \newcommand{\cul8r}{Goodbye!}

--- a/FAQ-ltx-csv.md
+++ b/FAQ-ltx-csv.md
@@ -1,6 +1,6 @@
 ---
 title: Process a CSV file in LaTeX
-cateogry: programming
+category: programming
 permalink: /FAQ-ltx-csv
 ---
 

--- a/FAQ-mathml.md
+++ b/FAQ-mathml.md
@@ -18,14 +18,14 @@ possibilities for good rendering of mathematics on the web.
   browsers was hampered by the limited range of symbols
   in the fonts that were available. However, all modern operating
   systems now include OpenType fonts with large collections of symbols
-  and the availablity of web font technology means that page authors
+  and the availability of web font technology means that page authors
   may specify fonts without relying on the reader having pre-installed
   suitable fonts.
 
 
   The available OpenType math fonts are discussed in [OpenType fonts](FAQ-otf-maths)
 
-- Direct interpretaton of a subset of LaTeX math markup by Javascript.
+- Direct interpretation of a subset of LaTeX math markup by Javascript.
   The speed of modern javaScript engines means that it is feasible to
   serve web pages that contain fragments of TeX markup that is converted
   in the reader's browser. Two main systems are in common use:
@@ -58,7 +58,7 @@ possibilities for good rendering of mathematics on the web.
 - Direct
   representation of mathematics MathML is a standard for representing
   maths on the Web; Browser support for MathML is provided by
-  `firefox`, and `safari` and other browsers using te same underlying
+  `firefox`, and `safari` and other browsers using the same underlying
   html rendering libraries.  At the current time it is not supported
   by Chrome or Edge browsers.  MathML in the page may be rendered by
   MathJax, with an output identical to its TeX r.endering. MathJax

--- a/FAQ-mcite.md
+++ b/FAQ-mcite.md
@@ -37,7 +37,7 @@ support for combined citations and so no longer even need
 [`mciteplus`](https://ctan.org/pkg/mciteplus) (but [`mciteplus`](https://ctan.org/pkg/mciteplus) is more general and will
 work with many other class and package combinations).
 
-The [`mciteplus`](https://ctan.org/pkg/mciteplus) package adresses many of the infelicites of
+The [`mciteplus`](https://ctan.org/pkg/mciteplus) package addresses many of the infelicites of
 [`mcite`](https://ctan.org/pkg/mcite).  Again, "ordinary" `bst` files will not
 work with [`mciteplus`](https://ctan.org/pkg/mciteplus), but the package documentation explains
 how to patch an existing BibTeX style.

--- a/FAQ-newcmdstar.md
+++ b/FAQ-newcmdstar.md
@@ -1,5 +1,5 @@
 ---
-title: Prefering `\newcommand*` over `\newcommand`
+title: Preferring `\newcommand*` over `\newcommand`
 category: programming
 tags:
   - latex

--- a/FAQ-noline.md
+++ b/FAQ-noline.md
@@ -47,7 +47,7 @@ in the environment:
 \begin{center}
   First (heading) line\\
   \\
-  body of the centerd text...
+  body of the centered text...
 \end{center}
 ```
 The solution here is plain: use the `\\` command in the way it's
@@ -58,7 +58,7 @@ be had by saying:
 ```latex
 \begin{center}
   First (heading) line\\[\baselineskip]
-  body of the centerd text...
+  body of the centered text...
 \end{center}
 ```
 
@@ -67,7 +67,7 @@ You _can_ use `\leavevmode`, as above:
 \begin{center}
   First (heading) line\\
   \leavevmode\\
-  body of the centerd text...
+  body of the centered text...
 \end{center}
 ```
 but that is just as tiresome to type as `\\` with an optional

--- a/FAQ-noroom.md
+++ b/FAQ-noroom.md
@@ -45,7 +45,7 @@ TeX would not help. You could however, try with LuaLaTeX which has larger
 limits in most cases.
 
 One related error is an error that the number of `\inserts` has been exceeded.
-An insert is not a register type but requires allcation of matching count, skip
+An insert is not a register type but requires allocation of matching count, skip
 dimen registers with the same number, in all current engines there can be at most 256
 inserts. You are unlikely to get this error on a LaTeX format newer than 2015, however
 if you have to use an old format the [`Morefloats`](https://ctan.org/pkg/Morefloats) package

--- a/FAQ-patch.md
+++ b/FAQ-patch.md
@@ -55,7 +55,7 @@ and then repeat the technique we had above, with one extension:
              {\mumble\OldRough[{#1}]{#2}}
 ```
 We see here that (for tedious argument-matching reasons) it is
-necessary to provide braces arround the optional argument that is
+necessary to provide braces around the optional argument that is
 being passed on.
 
 The general case may be achieved in two ways.  First, one can use the

--- a/FAQ-prevlig.md
+++ b/FAQ-prevlig.md
@@ -8,7 +8,7 @@ date: 2021-04-18
 This is a strength of TeX: some pairs of letters are automatically replaced
 by a single glyph, for aesthetic reasons, as is done in letterpress.  For example,
 when an `f` and an `i` are placed next to each other, the hood of the `f` would
-normally tend collide with the tittle of the `i`, which wouldn't look very nice.
+normally tend collide with the title of the `i`, which wouldn't look very nice.
 TeX therefore replaces them with a new, prettier glyph: ﬁ.
 This merging of glyphs is called a ligature.
 

--- a/FAQ-privinst.md
+++ b/FAQ-privinst.md
@@ -29,7 +29,7 @@ kpsewhich -var-value TEXMFHOME
 ```
 (for example).  This will almost invariably return a pointer to a
 subdirectory `texmf` of your home directory; the commonest
-exception is Macintoshes, using MacTeX, where the diretory is
+exception is Macintoshes, using MacTeX, where the directory is
 conventionally `Library/texmf` in your home directory.
 
 If you can confirm that the technique does indeed work, install your

--- a/FAQ-psfchoice.md
+++ b/FAQ-psfchoice.md
@@ -124,7 +124,7 @@ Users should also consider the possibilities of typesetting
   adoption is so limited and what might be done about the problem, is
   to be found at <http://truetex.com/belleek.pdf>
 
-- MTPro2 Lite Pubish or Perish (Michael Spivak)
+- MTPro2 Lite Publish or Perish (Michael Spivak)
 
   A (functional) subset of the MathTime Pro 2 font set, that is made
   available, free, for general use.  While it does not offer the full

--- a/FAQ-ragright.md
+++ b/FAQ-ragright.md
@@ -11,7 +11,7 @@ corresponding `flushleft` environment) has a tendency to
 miss the "never" part, and will often create ridiculously short
 lines, for some minor benefit later in the paragraph.  The
 Plain TeX version of the command doesn't suffer this failing, but
-is rather conservative: it is loath to create too large a gap at the
+is rather conservative: it is loathe to create too large a gap at the
 end of the line, but in some circumstances&nbsp;&mdash; such as where
 [hyphenation is suppressed](FAQ-hyphoff)&nbsp;&mdash; painfully large gaps
 may sometimes be required.

--- a/FAQ-repeat-num.md
+++ b/FAQ-repeat-num.md
@@ -18,7 +18,7 @@ repeating operations once for each of a set of objects is dealt with
 in the answer [repeating "over a set"](FAQ-repeat-set).
 
 Plain TeX itself provides a `\loop` &hellip; `\repeat`
-contruct, which enables you to repeat a command (or set of commands).
+construct, which enables you to repeat a command (or set of commands).
 The syntax is simple enough, but it use of TeX conditionals is
 different enough that many people find it confusing.
 ```latex

--- a/FAQ-secthead.md
+++ b/FAQ-secthead.md
@@ -6,7 +6,7 @@ permalink: /FAQ-secthead
 ---
 
 Suppose that the editor of your favourite journal has specified that section
-headings must be centerd, in small capitals, and subsection headings ragged 
+headings must be centered, in small capitals, and subsection headings ragged 
 right in italic, but that you don't want to get involved in the sort of
 programming described in section 2.2 of _The LaTeX Companion_
   (see [LaTeX books](FAQ-latex-books); the

--- a/FAQ-texdraw.md
+++ b/FAQ-texdraw.md
@@ -14,7 +14,7 @@ in a graphics interface.
 - [Inkscape](https://inkscape.org/) is a free and open-source vector graphics
   editor, that can export TikZ code. Its range of features makes it a very
   powerful tool, compatible with LaTeX workflows, but not limited to them.
-  It's developped for Linux, MacOS and Windows
+  It's developed for Linux, MacOS and Windows
 
 - [Xfig](https://sourceforge.net/projects/mcj/files/) is a free and open-source
   vector graphics editor which runs on Linux.

--- a/FAQ-texorpdf.md
+++ b/FAQ-texorpdf.md
@@ -40,6 +40,6 @@ example above would become:
 \section{\filled{foo}{bar}}
 ```
 <!-- {% endraw %} -->
-and with that definition, the example will compile succesfully
+and with that definition, the example will compile successfully
 ([`hyperref`](https://ctan.org/pkg/hyperref) knows about the macro `\space`).
 

--- a/FAQ-thesis.md
+++ b/FAQ-thesis.md
@@ -14,5 +14,5 @@ up [double spacing](FAQ-linespace).
 If you want to write a new thesis class of your own, a good place to
 start is the University of California style, but remember that it's
 often difficult to produce a thesis that both looks good and conforms
-with the style that your univeristy demands.
+with the style that your university demands.
 


### PR DESCRIPTION
Found via `codespell -L te,crossreferences,protext,raison,braket,stil,theses,laf`

This is typos changes, which can be do in one go, as in https://github.com/texfaq/texfaq.github.io/blob/ba3220db3acde072457ede67fbc9520ca808240f/CONTRIBUTING.md